### PR TITLE
Fix EsgFactorDropdown to use real table name

### DIFF
--- a/cypress/integration/chartpage.spec.ts
+++ b/cypress/integration/chartpage.spec.ts
@@ -34,7 +34,7 @@ describe('/ChartPage URL ', () => {
     // Asses
     cy.contains('2015');
     cy.contains('2018');
-    cy.contains('emissionPerYear');
+    cy.contains('Emmisions of Greenhouse gases');
   });
 });
 

--- a/src/components/ChartPageHeaderComponent/ChartPageHeaderComponent.tsx
+++ b/src/components/ChartPageHeaderComponent/ChartPageHeaderComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { UrlParamsInterface } from '../../pages/ChartPage/ChartPage';
-import { Nace, Region } from '../../types';
+import { EuroStatTable, Nace, Region } from '../../types';
 import { SearchBar } from '../HeaderComponent/SearchBarComponent';
 import { EsgFactorDropdown } from './EsgSectorDropdownComponent';
 import { PeriodDropdown } from './PeriodDropDownComponent';
@@ -14,6 +14,8 @@ interface Props {
   esgFactorList: string[];
   urlParams: UrlParamsInterface;
   yearList: string[];
+  euroStatTableList: EuroStatTable[];
+  esgFactorInfo: EuroStatTable;
 }
 export const ChartPageHeaderComponent: React.FC<Props> = ({
   regionList,
@@ -21,6 +23,8 @@ export const ChartPageHeaderComponent: React.FC<Props> = ({
   esgFactorList,
   urlParams,
   yearList,
+  euroStatTableList,
+  esgFactorInfo,
 }) => {
   return (
     <>
@@ -41,6 +45,8 @@ export const ChartPageHeaderComponent: React.FC<Props> = ({
         <ESGBox active={false}>
           <EsgFactorDropdown
             esgFactorList={esgFactorList}
+            euroStatTableList={euroStatTableList}
+            esgFactorInfo={esgFactorInfo}
             urlParams={urlParams}
           />
         </ESGBox>

--- a/src/components/ChartPageHeaderComponent/EsgSectorDropdownComponent.tsx
+++ b/src/components/ChartPageHeaderComponent/EsgSectorDropdownComponent.tsx
@@ -2,21 +2,23 @@ import React from 'react';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { UrlParamsInterface } from '../../pages/ChartPage/ChartPage';
+import { EuroStatTable } from '../../types';
 
 interface Props {
-  esgFactorList: string[];
+  esgFactorList: string[]; // TODO: This is not used any more. Remove.
   urlParams: UrlParamsInterface;
+  euroStatTableList: EuroStatTable[];
+  esgFactorInfo: EuroStatTable;
 }
 
 export const EsgFactorDropdown: React.FC<Props> = (props) => {
-  //const { setSearchQuery } = useQuery();
-  //const history = useHistory();
   const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
   const [chosenFactor, setChosenFactor] = useState<string>(
-    props.urlParams.esgFactor,
+    props.esgFactorInfo.datasetName || props.urlParams.esgFactor,
   );
   const [userInput, setUserInput] = useState<string>('');
 
+  // TODO: Keypress does not work after refactor to EsgFactorInfo. Fix this
   const handleKeywordKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       if (props.esgFactorList.includes(userInput)) {
@@ -42,12 +44,12 @@ export const EsgFactorDropdown: React.FC<Props> = (props) => {
     setDropdownOpen(false);
     setUserInput('');
   };
-  const handleEsgFactorClick = (esgfactorString: string): void => {
-    setChosenFactor(esgfactorString);
-    setUserInput(esgfactorString);
+  const handleEsgFactorClick = (esgFactor: EuroStatTable): void => {
+    setChosenFactor(esgFactor.datasetName);
+    setUserInput(esgFactor.datasetName);
     props.urlParams.setUrlParams(
       props.urlParams.naceRegionIdString,
-      esgfactorString, // Setting new esgFactorString
+      esgFactor.attributeName, // Setting new esgFactorString
       props.urlParams.yearStart,
       props.urlParams.yearEnd,
       props.urlParams.chosenTab,
@@ -70,24 +72,26 @@ export const EsgFactorDropdown: React.FC<Props> = (props) => {
         onKeyPress={handleKeywordKeyPress}
       />
       <DropdownContainer active={dropdownOpen}>
-        {props.esgFactorList
-          .filter((factor) => factor.includes(userInput))
-          .map((factorString: string, i: number) => (
+        {props.euroStatTableList
+          .filter((factor) => factor.datasetName?.includes(userInput))
+          .map((factor: EuroStatTable, i: number) => (
             <ResultRow
-              key={factorString}
-              id={factorString}
-              active={factorString === chosenFactor ? true : false}
+              key={factor.tableId}
+              id={factor.tableId.toString()}
+              active={factor.datasetName === chosenFactor ? true : false}
               onClick={() => {
-                handleEsgFactorClick(factorString);
+                handleEsgFactorClick(factor);
               }}
             >
-              <NameBox active={factorString === chosenFactor ? true : false}>
-                {factorString}
+              <NameBox
+                active={factor.datasetName === chosenFactor ? true : false}
+              >
+                {factor.datasetName}
               </NameBox>
               <CategoryBox
-                active={factorString === chosenFactor ? true : false}
+                active={factor.datasetName === chosenFactor ? true : false}
               >
-                Environment
+                {factor.esgFactor}
               </CategoryBox>
             </ResultRow>
           ))}

--- a/src/pages/ChartPage/ChartPage.tsx
+++ b/src/pages/ChartPage/ChartPage.tsx
@@ -94,9 +94,7 @@ export const ChartPage: React.FC<Props> = (props) => {
   const [esgFactorList, setEsgFactorList] = useState<string[]>();
   const [naceRegionList, setNaceRegionList] = useState<NaceRegion[]>([]);
   // List of all eurostat tables
-  const [, /*eurostatTableList*/ setEurostatTableList] = useState<
-    EuroStatTable[]
-  >();
+  const [eurostatTableList, setEurostatTableList] = useState<EuroStatTable[]>();
   // The currently chosen eurostat table
   const [esgFactorInfo, setEsgFactorInfo] = useState<EuroStatTable>();
 
@@ -228,7 +226,12 @@ export const ChartPage: React.FC<Props> = (props) => {
   // Render components
   return (
     <>
-      {esgFactorList && regionList && naceList && yearList ? (
+      {esgFactorList &&
+      regionList &&
+      naceList &&
+      yearList &&
+      esgFactorInfo &&
+      eurostatTableList ? (
         <ChartPageHeaderContainer>
           <ChartPageHeaderComponent
             regionList={regionList}
@@ -236,6 +239,8 @@ export const ChartPage: React.FC<Props> = (props) => {
             yearList={yearList}
             esgFactorList={esgFactorList}
             urlParams={urlParams}
+            esgFactorInfo={esgFactorInfo}
+            euroStatTableList={eurostatTableList}
           />
         </ChartPageHeaderContainer>
       ) : null}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,11 +19,11 @@ export interface RegionHasData {
 export interface EuroStatTable {
   tableId: number;
   tableCode?: string;
-  attributeName?: string;
+  attributeName: string;
   filters?: string;
   dataType?: string;
   unit?: string;
-  datasetName?: string;
+  datasetName: string;
   esgFactor?: string;
   description?: string;
   href?: string;


### PR DESCRIPTION
Use real table name instead of table code. And use dynamic esg factor
type instead of environmental taxes.